### PR TITLE
Fix `migrator.CreateTable` SQL Builder - Trailling commas in constraint and index clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,49 @@
 
 ## Quick Start
 
+You can simply test your connection to your database with the following:
 ```go
 import (
-  "github.com/ClickHouse/clickhouse-go"
+  "gorm.io/driver/clickhouse"
   "gorm.io/gorm"
 )
 
-// https://github.com/go-sql-driver/mysql
-dsn := "tcp://localhost:9910?debug=true"
-db, err := gorm.Open(sql.Open(dsn), &gorm.Config{})
+func main() {
+  dsn := "tcp://localhost:9000?debug=true"
+  db, err := gorm.Open(sql.Open(dsn), &gorm.Config{})
+  if err != nil {
+    panic(err)
+  }
+  // do something with db
+  // ...
+}
 ```
 
 
 ## Configuration
 
-TODO (iqdf)
 
 ```go
 import (
-  "gorm.io/driver/mysql"
+  "gorm.io/driver/clickhouse"
   "gorm.io/gorm"
 )
 
+// refer to https://github.com/ClickHouse/clickhouse-go
+const DSN = "tcp://localhost:9000?username=default&password=password&read_timeout=10&write_timeout=20"
+
 func main() {
-    // TODO (iqdf)
-}
+db, err := gorm.Open(clickhouse.New(mysql.Config{
+    DSN: DSN, 
+    DisableDatetimePrecision: true,   // disable datetime64 precision, not supported before clickhouse 20.4
+    DontSupportRenameColumn: true,    // rename column not supported before clickhouse 20.4
+    SkipInitializeWithVersion: false, // smart configure based on used version
+}), &gorm.Config{})
 ```
 
 ## Customized Driver
 
-TODO (iqdf)
+Customised driver is not supported. Currently there is only one driver that is tested against which is `"clickhouse"` driver from [ClickHouse/clickhouse-go](https://github.com/ClickHouse/clickhouse-go)
 
-```go
-import (
-  "gorm.io/driver/mysql"
-  "gorm.io/gorm"
-)
 
-func main() {
-    // TODO (iqdf)
-}
-```
+Checkout [https://gorm.io](https://gorm.io) for details.


### PR DESCRIPTION
## Description

Related Issues:
-  Issue #4: Bugs in CreateTable

Before, the SQL builder will has additional trailling commas when no constraint is specified. The template string for sprintf is the part that causes the issues:
```go
createTableSQL := "CREATE TABLE ? (%s , %s , %s) ENGINE=%s" // columnStr, constrStr, indexStr, engineStr
```

When `constrStr = ""` or `indexStr=""`, this causes unwanted commas in between: 
```go
createTableSQL := CREATE TABLE table_name (id Int64 , , ) ENGINE=MergeTree() ORDER BY tuple()
```

## Solution to Fix

```go
// fix the template, remove the commas
createTableSQL := "CREATE TABLE ? (%s %s %s) ENGINE=%s" // columnStr, constrStr, indexStr, engineStr

// ....
// build constraint check SQL string
if len(constrStr) > 0 {
   constrStr = ", " + constrStr
}

// ...
// build index clause SQL string
if len(indexStr) > 0 {
    indexStr = ", " + indexStr
}

// ...
// execute CREATE TABLE 
tx.Exec(...)
```