### PR TITLE
Added support for Table Engine using `gorm:table_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,44 +2,49 @@
 
 ## Quick Start
 
+You can simply test your connection to your database with the following:
 ```go
 import (
-  "github.com/ClickHouse/clickhouse-go"
+  "gorm.io/driver/clickhouse"
   "gorm.io/gorm"
 )
 
-// https://github.com/go-sql-driver/mysql
-dsn := "tcp://localhost:9910?debug=true"
-db, err := gorm.Open(sql.Open(dsn), &gorm.Config{})
+func main() {
+  dsn := "tcp://localhost:9000?debug=true"
+  db, err := gorm.Open(sql.Open(dsn), &gorm.Config{})
+  if err != nil {
+    panic(err)
+  }
+  // do something with db
+  // ...
+}
 ```
 
 
 ## Configuration
 
-TODO (iqdf)
 
 ```go
 import (
-  "gorm.io/driver/mysql"
+  "gorm.io/driver/clickhouse"
   "gorm.io/gorm"
 )
 
+// refer to https://github.com/ClickHouse/clickhouse-go
+const DSN = "tcp://localhost:9000?username=default&password=password&read_timeout=10&write_timeout=20"
+
 func main() {
-    // TODO (iqdf)
-}
+db, err := gorm.Open(clickhouse.New(mysql.Config{
+    DSN: DSN, 
+    DisableDatetimePrecision: true,   // disable datetime64 precision, not supported before clickhouse 20.4
+    DontSupportRenameColumn: true,    // rename column not supported before clickhouse 20.4
+    SkipInitializeWithVersion: false, // smart configure based on used version
+}), &gorm.Config{})
 ```
 
 ## Customized Driver
 
-TODO (iqdf)
+Customised driver is not supported. Currently there is only one driver that is tested against which is `"clickhouse"` driver from [ClickHouse/clickhouse-go](https://github.com/ClickHouse/clickhouse-go)
 
-```go
-import (
-  "gorm.io/driver/mysql"
-  "gorm.io/gorm"
-)
 
-func main() {
-    // TODO (iqdf)
-}
-```
+Checkout [https://gorm.io](https://gorm.io) for details.

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -23,7 +23,7 @@ type Config struct {
 	Conn                      gorm.ConnPool
 	DisableDatetimePrecision  bool
 	DontSupportRenameColumn   bool
-	SkipInitializeWithVersion bool
+	AutoInitializeWithVersion bool
 }
 
 type Dialector struct {
@@ -162,7 +162,7 @@ func (dialector Dialector) QuoteTo(writer clause.Writer, str string) {
 }
 
 func (dialector Dialector) Explain(sql string, vars ...interface{}) string {
-	return logger.ExplainSQL(sql, nil, `"`, vars...)
+	return logger.ExplainSQL(sql, nil, `'`, vars...)
 }
 
 func (dialectopr Dialector) SavePoint(tx *gorm.DB, name string) error {

--- a/examples/main.go
+++ b/examples/main.go
@@ -35,32 +35,43 @@ type Employee struct {
 }
 
 type Employer struct {
-	Name      string `gorm:"index; check:name_checker, name <> 'jinzhu'"`
+	Name      string `gorm:"index,comment:'thisisnameindex';check:name_checker,name <> 'jinzhu'"`
 	FirstName string `gorm:"index:idx_name,unique; check:concat(first_name, ' ', last_name) <> 'jinzhu zhang'"`
-	LastName  string `gorm:"index:idx_name,unique"`
-	Age       int64  `gorm:"index:,class:FULLTEXT,comment:hello \\, world,where:age > 10; check: age > 20"`
-	WorkYear  int64  `gorm:"index:, check:workchecker, work_year > (age + 18)"`
+	LastName  string `gorm:"index:idx_name,unique,comment:'thisislastnameindex'"`
+	Username  string `gorm:"index:,type:minmax,length:10,where:name3 != 'jinzhu'"`
+	Age       int64  `gorm:"index:,class:FULLTEXT,comment:'helloworld',where:age > 10;check:age > 20"`
+	WorkYear  int64  `gorm:"index:;check:workchecker,work_year > (age + 18)"`
+	Comment   string `gorm:"comment:'this is a comment field'"`
 }
 
-const DSNf = "tcp://%s:%s?database=%s&username=%s&password=%s&read_timeout=10&write_timeout=20"
+type DefaultAndComment struct {
+	DefaultStr    string `gorm:"default:'ThisIsDefaultEyy!'"`
+	DefaultNum64  int64  `gorm:"default:199000141"`
+	DefaultNumm64 int64  `gorm:"default:toInt64(199000143)"`
+	DefaultNum    int    `gorm:"default:1990000142"`
+	CommentF      string `gorm:"comment:'this is a comment field ay'"`
+}
+
+const DSNf = "tcp://%s:%s?database=%s&username=%s&password=%s&read_timeout=10&write_timeout=20&debug=%t"
 
 func main() {
 	var (
-		Host = "localhost"
-		Port = "9000"
+		Host  = "localhost"
+		Port  = "9000"
+		Debug = true
 
 		DBName    = "testdb"
 		DBUser    = "default"
 		DBPasword = ""
 	)
 
-	dsn := fmt.Sprintf(DSNf, Host, Port, DBName, DBUser, DBPasword)
+	dsn := fmt.Sprintf(DSNf, Host, Port, DBName, DBUser, DBPasword, Debug)
 	conn, err := gorm.Open(clickhouse.Open(dsn), &gorm.Config{})
 	if err != nil {
 		panic(err)
 	}
 
-	if err := conn.AutoMigrate(&SampleOne{}, &SampleTwo{}, &Employee{}, &Employer{}); err != nil {
+	if err := conn.AutoMigrate(&SampleOne{}, &SampleTwo{}, &Employee{}, &Employer{}, &DefaultAndComment{}); err != nil {
 		fmt.Println("errors?", err)
 	}
 }

--- a/migrator.go
+++ b/migrator.go
@@ -13,8 +13,9 @@ import (
 
 // Default values for any SQL options
 const (
-	DefaultIndexType   = "minmax" // index stores extremes of the expression
-	DefaultGranularity = 1        // 1 granule = 8192 rows
+	DefaultGranularity     = 1        // 1 granule = 8192 rows
+	DefaultIndexType       = "minmax" // index stores extremes of the expression
+	DefaultTableEngineOpts = "ENGINE=MergeTree() ORDER BY tuple()"
 )
 
 // Errors enumeration
@@ -36,11 +37,30 @@ func (m Migrator) CurrentDatabase() (name string) {
 	return
 }
 
-func (m Migrator) FullDataTypeOf(field *schema.Field) clause.Expr {
-	expr := m.Migrator.FullDataTypeOf(field)
-	if value, ok := field.TagSettings["COMMENT"]; ok {
-		expr.SQL += "COMMENT" + m.Dialector.Explain("?", value)
+func (m Migrator) FullDataTypeOf(field *schema.Field) (expr clause.Expr) {
+	expr.SQL = m.Migrator.DataTypeOf(field)
+
+	// NULL and UNIQUE keyword is not supported in clickhouse.
+	// Hence, skipping checks for field.Unique and field.NotNull
+
+	// Build DEFAULT clause after DataTypeOf() expression.
+	if field.HasDefaultValue && (field.DefaultValueInterface != nil || field.DefaultValue != "") {
+		if field.DefaultValueInterface != nil {
+			defaultStmt := &gorm.Statement{Vars: []interface{}{field.DefaultValueInterface}}
+			m.Dialector.BindVarTo(defaultStmt, defaultStmt, field.DefaultValueInterface)
+			expr.SQL += " DEFAULT " + m.Dialector.Explain(defaultStmt.SQL.String(), field.DefaultValueInterface)
+		} else if field.DefaultValue != "(-)" {
+			expr.SQL += " DEFAULT " + field.DefaultValue
+		}
 	}
+
+	// Build COMMENT clause after DEFAULT
+	if value, ok := field.TagSettings["COMMENT"]; ok {
+		expr.SQL += " COMMENT " + m.Dialector.Explain("?", value)
+	}
+
+	// TODO (iqdf) build CODEC and TTL clause
+
 	return expr
 }
 
@@ -51,7 +71,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 		tx := m.DB.Session(new(gorm.Session))
 		if err := m.RunWithValue(model, func(stmt *gorm.Statement) (err error) {
 			var (
-				createTableSQL = "CREATE TABLE ? (%s %s %s) ENGINE=%s"
+				createTableSQL = "CREATE TABLE ? (%s %s %s) %s"
 				args           = []interface{}{clause.Table{Name: stmt.Table}}
 			)
 
@@ -62,7 +82,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 				columnSlice = append(columnSlice, "? ?")
 				args = append(args,
 					clause.Column{Name: dbName},
-					m.DB.Migrator().FullDataTypeOf(field),
+					m.FullDataTypeOf(field),
 				)
 			}
 			columnStr := strings.Join(columnSlice, ",")
@@ -82,7 +102,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 			}
 
 			// Step 3. Build index SQL string
-			// NOTE: index class [UNIQUE | FULLTEXT | SPATIAL] is NOT supported!
+			// NOTE: clickhouse does not support for index class.
 			indexSlice := make([]string, 0, 10)
 			for _, index := range stmt.Schema.ParseIndexes() {
 				if m.CreateIndexAfterCreateTable {
@@ -121,7 +141,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 			}
 
 			// Step 4. Finally assemble CREATE TABLE ... SQL string
-			engineOpts := "MergeTree() ORDER BY tuple()"
+			engineOpts := DefaultTableEngineOpts
 			createTableSQL = fmt.Sprintf(createTableSQL, columnStr, constrStr, indexStr, engineOpts)
 
 			fmt.Println("Exec Create Table:", createTableSQL)
@@ -149,6 +169,18 @@ func (m Migrator) HasTable(value interface{}) bool {
 }
 
 // Columns
+
+func (m Migrator) AddColumn(value interface{}, field string) error {
+	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		if field := stmt.Schema.LookUpField(field); field != nil {
+			return m.DB.Exec(
+				"ALTER TABLE ? ADD COLUMN ? ?",
+				clause.Table{Name: stmt.Table}, clause.Column{Name: field.DBName}, m.DB.Migrator().FullDataTypeOf(field),
+			).Error
+		}
+		return fmt.Errorf("failed to look up field with name: %s", field)
+	})
+}
 
 func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {

--- a/migrator.go
+++ b/migrator.go
@@ -142,6 +142,9 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 
 			// Step 4. Finally assemble CREATE TABLE ... SQL string
 			engineOpts := DefaultTableEngineOpts
+			if tableOption, ok := m.DB.Get("gorm:table_options"); ok {
+				engineOpts = fmt.Sprint(tableOption)
+			}
 			createTableSQL = fmt.Sprintf(createTableSQL, columnStr, constrStr, indexStr, engineOpts)
 
 			fmt.Println("Exec Create Table:", createTableSQL)


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Non breaking API changes
- [x] Tested 

### Tested for:

- manually for `CREATE TABLE` only. 
- `ALTER COLUMN` and `ALTER INDEX ` still failling. But it is out of scope for this PR

### What did this pull request do?

#### 1. Add support for clickhouse `Table Engine` using

```
engineOpts := DefaultTableEngineOpts
			if tableOption, ok := m.DB.Get("gorm:table_options"); ok {
				engineOpts = fmt.Sprint(tableOption)
			}
```

#### 2. Update the `examples/main.go`

Update examples with different option for index, constraint, and column type.

### User Case Description

See [Clickhouse Table Engine](https://clickhouse.tech/docs/en/engines/table-engines/mergetree-family/mergetree/#primary-keys-and-indexes-in-queries)