### PR TITLE
Fixed AddColumn SQL builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GORM MySQL Driver
+# GORM ClickHouse Driver
 
 ## Quick Start
 

--- a/migrator.go
+++ b/migrator.go
@@ -14,7 +14,8 @@ import (
 // Default values for any SQL options
 const (
 	DefaultGranularity     = 1        // 1 granule = 8192 rows
-	DefaultIndexType       = "minmax" // index stores extremes of the expression
+	DefaultIndexType       = "minmax" // default index stores extremes of the expression
+	DefaultCompression     = "LZ4"    // default compression algorithm. LZ4 is lossless
 	DefaultTableEngineOpts = "ENGINE=MergeTree() ORDER BY tuple()"
 )
 
@@ -38,12 +39,14 @@ func (m Migrator) CurrentDatabase() (name string) {
 }
 
 func (m Migrator) FullDataTypeOf(field *schema.Field) (expr clause.Expr) {
+	// Infer the ClickHouse datatype from schema.Field information
 	expr.SQL = m.Migrator.DataTypeOf(field)
 
+	// NOTE:
 	// NULL and UNIQUE keyword is not supported in clickhouse.
 	// Hence, skipping checks for field.Unique and field.NotNull
 
-	// Build DEFAULT clause after DataTypeOf() expression.
+	// Build DEFAULT clause after DataTypeOf() expression optionally
 	if field.HasDefaultValue && (field.DefaultValueInterface != nil || field.DefaultValue != "") {
 		if field.DefaultValueInterface != nil {
 			defaultStmt := &gorm.Statement{Vars: []interface{}{field.DefaultValueInterface}}
@@ -54,12 +57,26 @@ func (m Migrator) FullDataTypeOf(field *schema.Field) (expr clause.Expr) {
 		}
 	}
 
-	// Build COMMENT clause after DEFAULT
-	if value, ok := field.TagSettings["COMMENT"]; ok {
-		expr.SQL += " COMMENT " + m.Dialector.Explain("?", value)
+	// Build COMMENT clause optionally after DEFAULT
+	if comment, ok := field.TagSettings["COMMENT"]; ok {
+		expr.SQL += " COMMENT " + m.Dialector.Explain("?", comment)
 	}
 
-	// TODO (iqdf) build CODEC and TTL clause
+	// Build CODEC compression algorithm optionally
+	// NOTE: the codec algo name is case sensitive!
+	if codecstr, ok := field.TagSettings["CODEC"]; ok && codecstr != "" {
+		// parse codec one by one in the codec option
+		codecSlice := make([]string, 0, 10)
+		for _, codec := range strings.Split(codecstr, ",") {
+			codecSlice = append(codecSlice, codec)
+		}
+		codecArgsSQL := DefaultCompression
+		if len(codecSlice) > 0 {
+			codecArgsSQL = strings.Join(codecSlice, ",")
+		}
+		codecSQL := fmt.Sprintf(" CODEC(%s) ", codecArgsSQL)
+		expr.SQL += codecSQL
+	}
 
 	return expr
 }

--- a/migrator.go
+++ b/migrator.go
@@ -150,6 +150,32 @@ func (m Migrator) HasTable(value interface{}) bool {
 
 // Columns
 
+func (m Migrator) AddColumn(value interface{}, field string) error {
+	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		if field := stmt.Schema.LookUpField(field); field != nil {
+			return m.DB.Exec(
+				"ALTER TABLE ? ADD COLUMN ? ?",
+				clause.Table{Name: stmt.Table}, clause.Column{Name: field.DBName},
+				m.FullDataTypeOf(field),
+			).Error
+		}
+		return fmt.Errorf("failed to look up field with name: %s", field)
+	})
+}
+
+func (m Migrator) DropColumn(value interface{}, name string) error {
+	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
+		if field := stmt.Schema.LookUpField(name); field != nil {
+			name = field.DBName
+		}
+		fmt.Println("ALTER TABLE ? DROP COLUMN")
+		return m.DB.Exec(
+			"ALTER TABLE ? DROP COLUMN ?",
+			clause.Table{Name: stmt.Table}, clause.Column{Name: name},
+		).Error
+	})
+}
+
 func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(field); field != nil {


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [] Tested

### What did this pull request do?

Fixed syntax for `ALTER TABLE ? ADD COLUMN ?` by defining a function:

```
func(m Migrator) AddColumn(value interface{}, name string) error
```

According to the official [ClickHouse docs](https://clickhouse.tech/docs/en/sql-reference/statements/alter/column/):
```
ADD COLUMN [IF NOT EXISTS] name [type] [default_expr] [codec] [AFTER name_after]
```
- The statement sure require **name** and **type** of column
- The statement clause supports adding **Default expr** and **codec** immediately in the `ADD COLUMN`
- The statement also supports the ordering of column using `AFTER name_after`, so that the order which of scanning fields is predictable and consistent. Otherwise new column will always put as the last column to scan.
- The statement doesn't support adding **TTL Expr**

### Feature done in `ADD COLUMN`

- [x] Ensure correctness for `name` and `TYPE` of column

- [x] Support specifying `DEFAULT expr` and `Codec` from golang tag `gorm:"[column_options]..."`

- [ ] Enable auto ordering using name `AFTER name_after`. 

## Tests:

Manual testing. 