### PR TITLE
Added Granularity Index Option in `CreateTable()` and `AddIndex()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GORM MySQL Driver
+# GORM ClickHouse Driver
 
 ## Quick Start
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -86,7 +86,7 @@ type DefaultAndComment struct {
 
 // MyIndexedTable (`my_indexed_tables`) table demonstrate more complex indexing expression
 type MyIndexedStuff struct {
-	U64 uint64 `gorm:"index:a,expression:u64*i32,type:minmax,granularity:3"`
+	U64 uint64 `gorm:"index:a,expression:u64*i32,type:minmax,granularity:10"`
 	I32 int32  `gorm:"index:b,expression:u64*length(ss),type:set(1000),granularity:4"`
 	SS  string `gorm:"index"`
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -8,7 +8,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// SampleOne has no constraint and no index during create table
+// SampleOne (`sample_ones`) table has no constraint and no index during create table
 type SampleOne struct {
 	ID        uint
 	Name      string
@@ -17,39 +17,78 @@ type SampleOne struct {
 	UpdatedAt time.Time
 }
 
-// SampleTwo has constraint to check but no index during create table
+// SampleTwo (`sample_twos`) table has constraint to check but no index during create table
 type SampleTwo struct {
 	ID    uint
 	Name  string `gorm:"check:name_checker,name <> 'jinzhu'"`
 	Email string `gorm:"check:email <> 'diku@gmail.com'"`
 }
 
+// Employee (`employees`) table demonstrate support for INDEX during create or migrate
+// table. In particular we cover the options for index:
+// - expression
+// - type
+// - renaming index
+//
+// Meanwhile some other options are not supported in clickhouse, hence ignored
+// when you add it in the tags:
+// - sort
+// - unique
+// - collate
+// - length
+// - class
+// - comment
+// - check
+// - where
+//
+// See the official docs of ClickHouse:
+// https://clickhouse.tech/docs/en/sql-reference/statements/alter/index/
 type Employee struct {
 	Name      string `gorm:"index"`
-	FirstName string `gorm:"index:idx_name,unique"`
-	LastName  string `gorm:"index:idx_name,unique"`
-	Username  string `gorm:"index:,sort:desc,collate:utf8,type:minmax,length:10,where:name3 != 'jinzhu'"`
-	Password  string `gorm:"uniqueIndex"`
-	Age       int64  `gorm:"index:,class:FULLTEXT,comment:hello \\, world,where:age > 10"`
+	FirstName string `gorm:"index:idx_name"`
+	LastName  string `gorm:"index:idx_name"`
+	Username  string `gorm:"index:,type:minmax,length:10"`
+	Password  string `gorm:"index"`
+	Age       int64  `gorm:"index"`
 	Age2      int64  `gorm:"index:,expression:ABS(age)"`
 }
 
+// Employer (`employers`)table demonstrate support for INDEX during create or migrate
+// table. In particular we cover the options as described in Employee comment docs.
+// Also we demonstrate how we combine index and constraint checks in one table
+// creation at one go.
+//
+// NOTE that some of the index options here you will see below is not supported by clickhouse
+// so nothing happened if you add the index option like unique, check, where, etc.
+//
+// See comments in Employee (`employees`) table or check official docs of clickhouse
+// https://clickhouse.tech/docs/en/sql-reference/statements/alter/index/
 type Employer struct {
-	Name      string `gorm:"index,comment:'thisisnameindex';check:name_checker,name <> 'jinzhu'"`
+	Name      string `gorm:"index; check:name_checker,name <> 'jinzhu'"`
 	FirstName string `gorm:"index:idx_name,unique; check:concat(first_name, ' ', last_name) <> 'jinzhu zhang'"`
-	LastName  string `gorm:"index:idx_name,unique,comment:'thisislastnameindex'"`
-	Username  string `gorm:"index:,type:minmax,length:10,where:name3 != 'jinzhu'"`
-	Age       int64  `gorm:"index:,class:FULLTEXT,comment:'helloworld',where:age > 10;check:age > 20"`
-	WorkYear  int64  `gorm:"index:;check:workchecker,work_year > (age + 18)"`
+	LastName  string `gorm:"index:idx_name"`
+	Username  string `gorm:"index:,type:minmax"`
+	Age       int64  `gorm:"index; check:age > 20"`
+	WorkYear  int64  `gorm:"index; check:workchecker,work_year > (age + 18)"`
 	Comment   string `gorm:"comment:'this is a comment field'"`
 }
 
+// DefaultAndComment (`default_and_comments`) table demonstrate support for INDEX
+// during create or migrate table. In particular we cover the options for index:
 type DefaultAndComment struct {
 	DefaultStr    string `gorm:"default:'ThisIsDefaultEyy!'"`
 	DefaultNum64  int64  `gorm:"default:199000141"`
 	DefaultNumm64 int64  `gorm:"default:toInt64(199000143)"`
 	DefaultNum    int    `gorm:"default:1990000142"`
 	CommentF      string `gorm:"comment:'this is a comment field ay'"`
+	// ExtraDefaultComm string `gorm:"default:'This is Default Ayyyay';comment:'this is a comment field ay'"`
+}
+
+// MyIndexedTable (`my_indexed_tables`) table demonstrate more complex indexing expression
+type MyIndexedStuff struct {
+	U64 uint64 `gorm:"index:a,expression:u64*i32,type:minmax,granularity:3"`
+	I32 int32  `gorm:"index:b,experssion:u64*length(ss),type:set(1000),granularity:4"`
+	SS  string `gorm:"index"`
 }
 
 const DSNf = "tcp://%s:%s?database=%s&username=%s&password=%s&read_timeout=10&write_timeout=20&debug=%t"
@@ -71,7 +110,14 @@ func main() {
 		panic(err)
 	}
 
-	if err := conn.AutoMigrate(&SampleOne{}, &SampleTwo{}, &Employee{}, &Employer{}, &DefaultAndComment{}); err != nil {
+	if err := conn.AutoMigrate(
+		&SampleOne{},
+		&SampleTwo{},
+		&Employee{},
+		&Employer{},
+		&DefaultAndComment{},
+		&MyIndexedStuff{},
+	); err != nil {
 		fmt.Println("errors?", err)
 	}
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -87,7 +87,7 @@ type DefaultAndComment struct {
 // MyIndexedTable (`my_indexed_tables`) table demonstrate more complex indexing expression
 type MyIndexedStuff struct {
 	U64 uint64 `gorm:"index:a,expression:u64*i32,type:minmax,granularity:3"`
-	I32 int32  `gorm:"index:b,experssion:u64*length(ss),type:set(1000),granularity:4"`
+	I32 int32  `gorm:"index:b,expression:u64*length(ss),type:set(1000),granularity:4"`
 	SS  string `gorm:"index"`
 }
 

--- a/migrator.go
+++ b/migrator.go
@@ -3,6 +3,7 @@ package clickhouse
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"gorm.io/gorm"
@@ -13,9 +14,9 @@ import (
 
 // Default values for any SQL options
 const (
-	DefaultGranularity     = 1        // 1 granule = 8192 rows
-	DefaultIndexType       = "minmax" // default index stores extremes of the expression
+	DefaultGranularity     = 3        // 1 granule = 8192 rows
 	DefaultCompression     = "LZ4"    // default compression algorithm. LZ4 is lossless
+	DefaultIndexType       = "minmax" // index stores extremes of the expression
 	DefaultTableEngineOpts = "ENGINE=MergeTree() ORDER BY tuple()"
 )
 
@@ -148,7 +149,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 
 				// Stringify index builder
 				// TODO (iqdf): support granularity
-				str := fmt.Sprintf("INDEX ? ? TYPE %s GRANULARITY %d", indexType, DefaultGranularity)
+				str := fmt.Sprintf("INDEX ? ? TYPE %s GRANULARITY %d", indexType, m.getIndexGranularityOption(index.Fields))
 				indexSlice = append(indexSlice, str)
 				args = append(args, clause.Expr{SQL: index.Name}, indexOptions)
 			}
@@ -333,4 +334,36 @@ func (m Migrator) DropIndex(value interface{}, name string) error {
 			clause.Table{Name: stmt.Table},
 			clause.Column{Name: name}).Error
 	})
+}
+
+// Helper
+
+// Index
+
+func (m Migrator) getIndexGranularityOption(opts []schema.IndexOption) int {
+	for _, indexOpt := range opts {
+		if settingStr, ok := indexOpt.Field.TagSettings["INDEX"]; ok {
+			// e.g. settingStr: "a,expression:u64*i32,type:minmax,granularity:3"
+			for _, str := range strings.Split(settingStr, ",") {
+				// e.g. str: "granularity:3"
+				keyVal := strings.Split(str, ":")
+				if len(keyVal) > 1 && strings.ToLower(keyVal[0]) == "granularity" {
+					if len(keyVal) < 2 {
+						// continue search for other setting which
+						// may contain granularity:<num>
+						continue
+					}
+					// try to convert <num> into an integer > 0
+					// if check fails, continue search for other
+					// settings which may contain granularity:<num>
+					num, err := strconv.Atoi(keyVal[1])
+					if err != nil || num < 0 {
+						continue
+					}
+					return num
+				}
+			}
+		}
+	}
+	return DefaultGranularity
 }

--- a/migrator.go
+++ b/migrator.go
@@ -292,25 +292,25 @@ func (m Migrator) BuildIndexOptions(opts []schema.IndexOption, stmt *gorm.Statem
 
 func (m Migrator) CreateIndex(value interface{}, name string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
-		if idx := stmt.Schema.LookIndex(name); idx != nil {
-			opts := m.BuildIndexOptions(idx.Fields, stmt)
+		if index := stmt.Schema.LookIndex(name); index != nil {
+			opts := m.BuildIndexOptions(index.Fields, stmt)
 			values := []interface{}{
 				clause.Table{Name: stmt.Table},
-				clause.Column{Name: idx.Name},
+				clause.Column{Name: index.Name},
 				opts,
 			}
 
 			// Get indexing type `gorm:"index,type:minmax"`
 			// Choice: minmax | set(n) | ngrambf_v1(n, size, hash, seed) | bloomfilter()
 			indexType := DefaultIndexType
-			if idx.Type != "" {
-				indexType = idx.Type
+			if index.Type != "" {
+				indexType = index.Type
 			}
 
 			// NOTE: concept of UNIQUE | FULLTEXT | SPATIAL index
 			// is NOT supported in clickhouse
-			createIndexSQL := "ALTER TABLE ? ADD INDEX ? ? TYPE %s GRANULARITY %d"      // TODO(iqdf): how to inject Granularity
-			createIndexSQL = fmt.Sprintf(createIndexSQL, indexType, DefaultGranularity) // Granularity: 1 (default)
+			createIndexSQL := "ALTER TABLE ? ADD INDEX ? ? TYPE %s GRANULARITY %d"                             // TODO(iqdf): how to inject Granularity
+			createIndexSQL = fmt.Sprintf(createIndexSQL, indexType, m.getIndexGranularityOption(index.Fields)) // Granularity: 1 (default)
 			return m.DB.Exec(createIndexSQL, values...).Error
 		}
 		return ErrCreateIndexFailed


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested (manually)

### What did this pull request do?
Added support for specifying `GRANULARITY` when building `INDEX` during create table and create index.
See official[ Clickhouse docs](https://clickhouse.tech/docs/en/sql-reference/statements/alter/index/) to know more about `INDEX syntax`

For `CreateTable()` operation, `GRANULARITY` can be specified just after the column expression clause:
```SQL
CREATE TABLE my_stuffs
(
    `u64` UInt64,
    `ss` String,
    INDEX idx_int (u64, ss) TYPE minmax GRANULARITY 11
)
ENGINE = MergeTree()
ORDER BY (u64, ss)
```

For `CreateIndex()` operation, `GRANULARITY` can be specified like:
```
ALTER TABLE [db].name ADD INDEX index_name (expression) TYPE index_type GRANULARITY granularity_int
```

### User Case Description

<!-- Your use case -->
The usecase is shown in the [`examples/main.go`](./examples/main.go)

```golang
// MyIndexedTable (`my_indexed_tables`) table demonstrate more complex indexing expression
type MyIndexedStuff struct {
	U64 uint64 `gorm:"index:a,expression:u64*i32,type:minmax,granularity:10"`
	I32 int32  `gorm:"index:b,expression:u64*length(ss),type:set(1000),granularity:4"`
	SS  string `gorm:"index"`
}

```

### Tests

Tested for both add index and create table. Manual settings. Compatible with other index settings without issue.

