### PR TITLE
supports creating table on cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ func main() {
 	// Set table options
 	db.Set("gorm:table_options", "ENGINE=Distributed(cluster, default, hits)").AutoMigrate(&User{})
 
+  // Set table cluster options
+	//db.Set("gorm:table_cluster_options", "on cluster default").AutoMigrate(&User{})
+
 	// Insert
 	db.Create(&User{Name: "Angeliz", Age: 18})
 

--- a/migrator.go
+++ b/migrator.go
@@ -81,7 +81,7 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 		tx := m.DB.Session(new(gorm.Session))
 		if err := m.RunWithValue(model, func(stmt *gorm.Statement) (err error) {
 			var (
-				createTableSQL = "CREATE TABLE ? (%s %s %s) %s"
+				createTableSQL = "CREATE TABLE ? %s (%s %s %s) %s"
 				args           = []interface{}{clause.Table{Name: stmt.Table}}
 			)
 
@@ -155,7 +155,12 @@ func (m Migrator) CreateTable(models ...interface{}) error {
 			if tableOption, ok := m.DB.Get("gorm:table_options"); ok {
 				engineOpts = fmt.Sprint(tableOption)
 			}
-			createTableSQL = fmt.Sprintf(createTableSQL, columnStr, constrStr, indexStr, engineOpts)
+			clusterOpts := ""
+			if clusterOption, ok := m.DB.Get("gorm:table_cluster_options"); ok {
+				clusterOpts = fmt.Sprint(clusterOption)
+			}
+
+			createTableSQL = fmt.Sprintf(createTableSQL, clusterOpts, columnStr, constrStr, indexStr, engineOpts)
 
 			err = tx.Exec(createTableSQL, args...).Error
 


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [√] Do only one thing
- [√] Non breaking API changes
- [√] Tested

### What did this pull request do?
Supports creating table on cluster , eg : 
CREATE TABLE [IF NOT EXISTS] [db.]table_name ON CLUSTER cluster
(
    name1 [type1] [DEFAULT|MATERIALIZED|ALIAS expr1],
    name2 [type2] [DEFAULT|MATERIALIZED|ALIAS expr2],
    ...
    INDEX index_name1 expr1 TYPE type1(...) GRANULARITY value1,
    INDEX index_name2 expr2 TYPE type2(...) GRANULARITY value2
) ENGINE = engine_name()
[PARTITION BY expr]
[ORDER BY expr]
[PRIMARY KEY expr]
[SAMPLE BY expr]
[SETTINGS name=value, ...];

OR:

CREATE TABLE  [db.]table_name  ON CLUSTER default
 AS db.local_table_name   ENGINE = Distributed(<cluster>, <database>, <shard table> [, sharding_key])
<!--
provide a general description of the code changes in your pull request
-->

### User Case Description
1. With table_cluster_options :
`db.Set("gorm:table_cluster_options", "on cluster default").AutoMigrate(&User{})
`
2. Without table_cluster_options

We use this in our prod env, and work well.

<!-- Your use case -->
