### PR TITLE
feat: add HasIndex in clickhouse Migrator

### DIFF
--- a/migrator_test.go
+++ b/migrator_test.go
@@ -78,3 +78,26 @@ func TestAutoMigrate(t *testing.T) {
 		}
 	}
 }
+
+func TestMigrator_HasIndex(t *testing.T) {
+	type UserWithIndex struct {
+		FirstName string    `gorm:"index:full_name"`
+		LastName  string    `gorm:"index:full_name"`
+		CreatedAt time.Time `gorm:"index"`
+	}
+	if DB.Migrator().HasIndex("users", "full_name") {
+		t.Fatalf("users's full_name index should not exists")
+	}
+
+	if err := DB.Table("users").AutoMigrate(&UserWithIndex{}); err != nil {
+		t.Fatalf("no error should happen when auto migrate")
+	}
+
+	if !DB.Migrator().HasIndex("users", "full_name") {
+		t.Fatalf("users's full_name index should exists after auto migrate")
+	}
+
+	if err := DB.Table("users").AutoMigrate(&UserWithIndex{}); err != nil {
+		t.Fatalf("no error should happen when auto migrate again")
+	}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?

In `AutoMigrate` we are supposed to call `HasIndex` in Migrator to detect the index. 

However, we can not use the following fallback SQL

```
SELECT count(*) FROM information_schema.statistics WHERE table_schema = ? AND table_name = ? AND index_name = ?
```

since there is no such table ( currently I am using the latest stable clickhouse `22.3.7.28`.

Here is a implementation of 'HasIndex' for clickhouse, which is extracting index names from create table statement.

<!--
provide a general description of the code changes in your pull request
-->

### User Case Description

<!-- Your use case -->

```
CREATE TABLE  my_database.my_foo_bar
(
    `id` UInt64,
    `created_at` DateTime64(3),
    `updated_at` DateTime64(3),
    `deleted_at` DateTime64(3),
    `foo` String,
    `bar` String,
    INDEX idx_my_foo_bar_deleted_at deleted_at TYPE minmax GRANULARITY 3,
    INDEX my_fb_foo_bar (foo, bar) TYPE minmax GRANULARITY 3
)
ENGINE = MergeTree
PARTITION BY toYYYYMM(created_at)
ORDER BY (foo, bar)
SETTINGS index_granularity = 8192
```


Any advice is appreciated

