### PR TITLE
Support ClickHouse versions with a suffix

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -88,7 +88,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	}
 
 	if !dialector.SkipInitializeWithVersion {
-		err = db.ConnPool.QueryRowContext(ctx, "SELECT version()").Scan(&dialector.Version)
+		err = db.ConnPool.QueryRowContext(ctx, "SELECT extract(version(), '([\d]+\.[\d]+\.[\d]+(\.[\d]+)?)'").Scan(&dialector.Version)
 		if err != nil {
 			return err
 		}

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -88,7 +88,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	}
 
 	if !dialector.SkipInitializeWithVersion {
-		err = db.ConnPool.QueryRowContext(ctx, "SELECT extract(version(), '([\d]+\.[\d]+\.[\d]+(\.[\d]+)?)'").Scan(&dialector.Version)
+		err = db.ConnPool.QueryRowContext(ctx, "SELECT extract(version(), '([\\d]+.[\\d]+.[\\d]+(.[\\d]+)?)'").Scan(&dialector.Version)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Altinity.Stable versions have a suffix in version name, e.g.:
```
select version(), extract(version(), '([\d]+\.[\d]+\.[\d]+(\.[\d]+)?)') version_cut
┌─version()─────────────────┬─version_cut─┐
│ 22.3.12.20.altinitystable │ 22.3.12.20  │
└───────────────────────────┴─────────────┘
```

This PR extracts a version number correctly w/o suffix.