### PR TITLE
Update create.go

### DIFF
--- a/create.go
+++ b/create.go
@@ -36,6 +36,7 @@ func (dialector *Dialector) Create(db *gorm.DB) {
 					if _, err := stmt.Exec(value...); db.AddError(err) != nil {
 						return
 					}
+					db.RowsAffected++
 				}
 				return
 			}


### PR DESCRIPTION
bugfix: When using the create or createInBatches methods with Byconity, RowsAffected is not set correctly

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [ ] Do only one thing
- [ ] Non breaking API changes
- [ ] Tested

### What did this pull request do?
When using the create or createInBatches methods with Byconity, RowsAffected is not set correctly

### User Case Description
batch insert any record can find the bug
