### PR TITLE
information_schema.tables.table_type changed from Enum8 to String

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -30,6 +30,8 @@ type Config struct {
 	DefaultCompression           string // default compression algorithm. LZ4 is lossless
 	DefaultIndexType             string // index stores extremes of the expression
 	DefaultTableEngineOpts       string
+
+	InformationSchemaTablesTableTypeString bool // information_schema.tables.table_type is String
 }
 
 type Dialector struct {
@@ -111,6 +113,11 @@ func (dialector *Dialector) Initialize(db *gorm.DB) (err error) {
 			versionNoPrecisionColumn, _ := version.NewConstraint("< 21.11")
 			if versionNoPrecisionColumn.Check(dbversion) {
 				dialector.DontSupportColumnPrecision = true
+			}
+
+			versionTableType, _ := version.NewConstraint(">= 23.9")
+			if versionTableType.Check(dbversion) {
+				dialector.Config.InformationSchemaTablesTableTypeString = true
 			}
 		}
 	}


### PR DESCRIPTION
The type of field information_schema.tables.table_type changed from Enum8 to String (#199)

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

clickhouse version 23.9 changelog
Made the views in schema information_schema more compatible with the equivalent views in MySQL
(i.e. modified and extended them) up to a point where Tableau Online is able to connect to ClickHouse.
More specifically:
1. The type of field information_schema.tables.table_type changed from Enum8 to String.
2. Added fields table_comment and table_collation to view information_schema.table.
3. Added views information_schema.key_column_usage and referential_constraints.
4. Replaced uppercase aliases in information_schema views with concrete uppercase columns.
https://github.com/ClickHouse/ClickHouse/pull/54773

version < 23.9 table_type Enum8('BASE TABLE' = 1, 'VIEW' = 2, 'FOREIGN TABLE' = 3, 'LOCAL TEMPORARY' = 4, 'SYSTEM VIEW' = 5)
version >= 23.9 table_type String
